### PR TITLE
Fix for Missing Trace of Exception when Opening Audio File | Issue #8

### DIFF
--- a/NWaveform.WPF/NAudio/NAudioPlayer.cs
+++ b/NWaveform.WPF/NAudio/NAudioPlayer.cs
@@ -175,7 +175,7 @@ namespace NWaveform.NAudio
             }
             catch (Exception ex)
             {
-                Error.Exception = new AudioException("Could not open audio", ex);
+                HandleError(ex);
             }
         }
 


### PR DESCRIPTION
Implemented the default Handling of an Error inside NAudioPlayer, so that the Error will also be traced, just like the other Errors/Exceptions.

Fix for Issue #8 